### PR TITLE
Feature: scraper parses search filters from database

### DIFF
--- a/scraper/main.py
+++ b/scraper/main.py
@@ -75,7 +75,7 @@ def update_db(con: sqlite3.Connection, cur_listings: Dict, ygl_url_base: str):
         name, val = filter_item
         if "Date" in name: # changing "YYYY-MM-DD" to "MM%2FDD%2FYYYY" for YGL parameter value
             year, month, day = val.split("-")
-            dl = "%2F" # delimiter (JH: yellow flag?)
+            dl = "%2F" # delimiter 
             val = f"{month}{dl}{day}{dl}{year}" 
         if name in filter_names:
             name = filter_names[name]


### PR DESCRIPTION
Scraper reads filters from database and parses them into YGL parameters. Currently supported filter names are:
| Filter Name    | Description |  
|---------|-------|
| `BedsMin `| Minimum number of desired bedrooms     | 
| `BedsMax` | Maximum number of desired bedrooms    | 
| `RentMin` | Minimum price for rent range     | 
| `RentMax` | Maximum price for rent range     | 
| `DateMin` | Earliest desired move-in date     | 
| `DateMax` | Latest desired move-in date     | 

## Example: 

From the SQLite database:
| name    | value |  
|---------|-------|
| `BedsMin` | `2`     | 
| `BedsMax` | `3`   | 
| `RentMin` | `1000`     | 

The scraper parses these rows into the parameters of the YGL url:
`https://ygl.is/broker-name?beds_from=2&beds_to=3&rent_from=1000`

Closes #21 

closes #19 as well, since we decided to use simpler date strings in the db