### PR TITLE
Feature: filtering for minimum and maximum number of bathrooms

### DIFF
--- a/dev/add_filters.sh
+++ b/dev/add_filters.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+sqlite3 ygl.db "INSERT INTO Filter (name, value) 
+VALUES 
+    ('BedsMin', 2), 
+    ('RentMax', 3400), 
+    ('DateMin', '2025-07-01'),  
+    ('DateMax', '2025-09-01'),
+    ('BathsMin', 1.5);"

--- a/dev/clear_brokers.sh
+++ b/dev/clear_brokers.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+./dev/clear_table.sh Broker

--- a/dev/clear_filters.sh
+++ b/dev/clear_filters.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+sqlite3 ygl.db "DELETE FROM Filter"

--- a/dev/clear_filters.sh
+++ b/dev/clear_filters.sh
@@ -1,2 +1,2 @@
 #!/bin/bash
-sqlite3 ygl.db "DELETE FROM Filter"
+./dev/clear_table.sh Filter

--- a/dev/clear_listings.sh
+++ b/dev/clear_listings.sh
@@ -1,2 +1,2 @@
 #!/bin/bash
-sqlite3 ygl.db "DELETE FROM Listing"
+./dev/clear_table.sh Listing

--- a/dev/clear_listings.sh
+++ b/dev/clear_listings.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+sqlite3 ygl.db "DELETE FROM Listing"

--- a/dev/clear_table.sh
+++ b/dev/clear_table.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+sqlite3 ygl.db "DELETE FROM $1"

--- a/dev/refresh_listings.sh
+++ b/dev/refresh_listings.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+./dev/clear_listings.sh
+./dev/run_scraper.sh

--- a/dev/run_scraper.sh
+++ b/dev/run_scraper.sh
@@ -1,0 +1,1 @@
+python scraper/main.py --db ygl.db

--- a/scraper/main.py
+++ b/scraper/main.py
@@ -13,18 +13,6 @@ from bs4 import BeautifulSoup
 from notify import notify, register_notifications
 
 
-# see ygl-server.go ConfigType
-class ConfigType(IntEnum):
-    """TODO: _summary_
-
-    :param IntEnum: _description_
-    :type IntEnum: _type_
-    """
-    INTEGER = 0
-    BOOLEAN = auto()
-    STRING = auto()
-    NOTIFICATION = auto()
-
 logger = logging.getLogger(__name__)
 logging.basicConfig(
     format='%(asctime)s - %(name)s - %(levelname)s - %(message)s',
@@ -115,7 +103,6 @@ def update_db(con: sqlite3.Connection, cur_listings: Dict, ygl_url_base: str):
             listing_beds = float(listing_props[1].split(' ')[0])
         except ValueError:
             listing_beds = 0
-        listing_baths = float(listing_props[2].split(' ')[0])
         listing_date = listing_props[3].split(' ')[1]
 
         # TODO: omg remove this I forgot it was here

--- a/scraper/main.py
+++ b/scraper/main.py
@@ -77,6 +77,7 @@ def update_db(con: sqlite3.Connection, cur_listings: Dict, ygl_url_base: str):
     min_baths = 0
     max_baths = 999
     ygl_params = []
+
     res = cursor.execute('SELECT * FROM Filter')
     for filter_item in res.fetchall():
         name, val = filter_item
@@ -91,6 +92,9 @@ def update_db(con: sqlite3.Connection, cur_listings: Dict, ygl_url_base: str):
             min_baths = float(val)
         elif name == "BathsMax":
             max_baths = float(val)
+
+    if min_baths == max_baths:
+        ygl_params.append(f"baths={min_baths}")
 
     for listing in ygl_listings(f'{ygl_url_base}?{"&".join(ygl_params)}'):
         listing_element = listing.find('a', class_='item_title')

--- a/scraper/main.py
+++ b/scraper/main.py
@@ -15,10 +15,15 @@ from notify import notify, register_notifications
 
 # see ygl-server.go ConfigType
 class ConfigType(IntEnum):
-	INTEGER = 0
-	BOOLEAN = auto() 
-	STRING = auto()
-	NOTIFICATION = auto()
+    """TODO: _summary_
+
+    :param IntEnum: _description_
+    :type IntEnum: _type_
+    """
+    INTEGER = 0
+    BOOLEAN = auto()
+    STRING = auto()
+    NOTIFICATION = auto()
 
 logger = logging.getLogger(__name__)
 logging.basicConfig(


### PR DESCRIPTION
Scraper reads bathroom filters from database. Discards any listings outside of given range of number of bathrooms. Supports half baths.

Supported filters added:
| Filter Name    | Description |  
|---------|-------|
| `BathsMin`| Minimum number of desired bathrooms| 
| `BathsMax` | Maximum number of desired bathrooms| 

## Example 1: 
From the table `Filter`:
| name    | value |  
|---------|-------|
| `BedsMin` | `2`     | 
| `BedsMax` | `3`   | 
| `RentMin` | `1000`  | 
| `BathsMin` | `1.5`     | 
| `BathsMax` | `3`   | 

The scraper parses the first three rows into the parameters of the YGL url:
`https://ygl.is/broker-name?beds_from=2&beds_to=3&rent_from=1000`

These results include listings with any number of baths. Then, the scraper filters out any listings where the number of baths is fewer than 1.5 or greater than 3.

## Example 2: 
From the table `Filter`:
| name    | value |  
|---------|-------|
| `BedsMin` | `2`     | 
| `BedsMax` | `3`   | 
| `RentMin` | `1000`  | 
| `BathsMin` | `1.5`     | 
| `BathsMax` | `1.5`   | 

In a special case, when `BathsMin` is equal to `BathsMax`, the number of baths is simply added to the url parameters:
`https://ygl.is/broker-name?beds_from=2&beds_to=3&rent_from=1000&baths=1.5`

Part of #27 